### PR TITLE
Add back a link to strollerstats.com since Strava now allows links in the description again

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -7,7 +7,8 @@
     "shell": "firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
-    "logs": "firebase functions:log"
+    "logs": "firebase functions:log",
+    "test": "node --test test/index.test.js"
   },
   "engines": {
     "node": "20"

--- a/functions/test/index.test.js
+++ b/functions/test/index.test.js
@@ -1,0 +1,67 @@
+const { describe, it, afterEach } = require("node:test");
+const assert = require("node:assert");
+const firebaseTest = require("firebase-functions-test")();
+
+// We need to import the function after initializing firebase-functions-test
+const { isAlreadyProcessed } = require("../index");
+
+describe("isAlreadyProcessed", () => {
+  afterEach(() => {
+    firebaseTest.cleanup();
+  });
+
+  it("should return false for null or undefined description", () => {
+    assert.strictEqual(isAlreadyProcessed(null), false);
+    assert.strictEqual(isAlreadyProcessed(undefined), false);
+    assert.strictEqual(isAlreadyProcessed(""), false);
+  });
+
+  it("should return false for description without any processed markers", () => {
+    const description = "Just a regular activity description";
+    assert.strictEqual(isAlreadyProcessed(description), false);
+  });
+
+  it("should return true for description with 'StrollerStats.com -' marker", () => {
+    const description = `Easy morning run with the kids
+
+#strollerstats
+StrollerStats.com - Monthly stats updated`;
+    assert.strictEqual(isAlreadyProcessed(description), true);
+  });
+
+  it("should return true for description with '| StrollerStats' marker", () => {
+    const description = `Traded off stroller with partner, so probably 2.75 miles with the stroller
+
+#strollerstats(2.75)
+15.2 January stroller run miles | StrollerStats`;
+    assert.strictEqual(isAlreadyProcessed(description), true);
+  });
+
+  it("should return true for description with '| strollerstats' marker", () => {
+    const description = `Hill repeats at the park
+#strollerstats
+8.5 February stroller walk miles | strollerstats`;
+    assert.strictEqual(isAlreadyProcessed(description), true);
+  });
+
+  it("should return true for description with '| https://www.strollerstats.com' marker", () => {
+    const description = `4x20s hills
+#StrollerStats
+12.3 March stroller run miles | https://www.strollerstats.com`;
+    assert.strictEqual(isAlreadyProcessed(description), true);
+  });
+
+  it("should return true when marker appears in middle of description", () => {
+    const description = `6am run before work
+#strollerstats(1.5)
+10.5 April stroller run miles | StrollerStats
+Great way to start the day!`;
+    assert.strictEqual(isAlreadyProcessed(description), true);
+  });
+
+  it("should handle case sensitivity correctly", () => {
+
+    // These SHOULD match (exact case)
+    assert.strictEqual(isAlreadyProcessed("contains | strollerstats marker"), true);
+  });
+});


### PR DESCRIPTION
Reverts the change in #8, but with a small update since strollerstats.com won't link anymore— we need at least www.strollerstats.com or https://www.strollerstats.com (let me know if we want to change to the more concise www.strollerstats.com). I can also break this PR into just the functionality and a separate PR for tests:

- Also refactors isAlreadyProcessed into a helper function and adds some tests for it
- Adds a command to run tests in functions using node-test.

I didn't want to add `mocha` or `chai` as dependencies and saw that this project recently bumped to node 20 so just added simple tests for the logic change (with a Claude-assist to generate the test cases) using `node-test` (which I believe requires > node 18. To run these:

```
cd functions
npm test

> test
> node --test test/index.test.js

▶ isAlreadyProcessed
  ✔ should return false for null or undefined description (0.616959ms)
  ✔ should return false for description without any processed markers (0.094833ms)
  ✔ should return true for description with 'StrollerStats.com -' marker (0.127166ms)
  ✔ should return true for description with '| StrollerStats' marker (0.088708ms)
  ✔ should return true for description with '| strollerstats' marker (0.145542ms)
  ✔ should return true for description with '| https://www.strollerstats.com' marker (0.079958ms)
  ✔ should return true when marker appears in middle of description (0.176667ms)
  ✔ should handle case sensitivity correctly (0.139667ms)
✔ isAlreadyProcessed (2.098709ms)
ℹ tests 8
ℹ suites 1
ℹ pass 8
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 350.672458
```
